### PR TITLE
endpoint for mask showing parts of the image that contributed to classification the most

### DIFF
--- a/quiver_engine/occlusion.py
+++ b/quiver_engine/occlusion.py
@@ -1,0 +1,53 @@
+from imagenet_utils import decode_predictions
+import numpy as np
+
+def occlusion_positions(size, img_size, overlap=0.0):
+    olf = 1 / (1 - overlap)
+    imgf = int(np.ceil(img_size / size))
+    return [int(i * size * (1 - overlap)) for i in range(int(olf * imgf)) if int(i * size * (1 - overlap)) < img_size]
+
+def generate_img_with_occlusion(img,x1,x2,y1,y2,occlusion_val=0):
+    imgc = np.copy(img)
+    imgc[y1:y2,x1:x2,:] = occlusion_val
+    return imgc
+
+def occlude_patches_and_predict(model, img,occ_size_w,occ_size_h,overlap=0.0):
+    for x in occlusion_positions(occ_size_h,img.shape[0],overlap):
+        for y in occlusion_positions(occ_size_w,img.shape[1],overlap):
+            imgc = generate_img_with_occlusion(img,x,x+occ_size_w,y,y+occ_size_h)
+            img_for_model = np.expand_dims(imgc,0)
+            pred = model.predict(img_for_model, batch_size=1, verbose=0)
+            decoded = decode_predictions(pred)[0]
+            yield({'pred':decoded,'x':x,'y':y})
+
+def occlude_and_predict(model,image_for_model):
+    img = image_for_model[0]
+    occ_size_w = int(np.floor(img.shape[0]/3))
+    occ_size_h = int(np.floor(img.shape[1]/3))
+    occluded_predictions = list(occlude_patches_and_predict(model,img,occ_size_w,occ_size_h,0.5))
+    baseline_pred = decode_predictions(model.predict(image_for_model))[0]
+    prediction_diffs = [predictions_diff_top(baseline_pred, occluded_prediction['pred']) for occluded_prediction in occluded_predictions]
+    results_diffs = [{'x': r['x'], 'y': r['y'], 'diff': diff} for r, diff in zip(occluded_predictions, prediction_diffs)]
+    return generate_mask(results_diffs,img.shape[0], img.shape[1],occ_size_w,occ_size_h)
+
+def generate_mask(x_y_and_diff,width,height,occ_size_w,occ_size_h):
+    mask = np.zeros((width,height, 3))
+    for occlusion_result in x_y_and_diff:
+        y = occlusion_result['y']
+        x = occlusion_result['x']
+        if (occlusion_result['diff'] > 0):
+            mask[y:y + occ_size_h, x:x + occ_size_w, :] += occlusion_result['diff']
+    return mask * (1.0 / mask.max())
+
+def predictions_diff_top(pred_1,pred_2):
+    pred_1 = np.array(pred_1)
+    pred_2 = np.array(pred_2)
+    top_code_from_1 = pred_1[0][0]
+    top_val_from_1 = pred_1[0][2]
+    predictions_for_top_in_2 = pred_2[pred_2[:,0] == top_code_from_1]
+    if (len(predictions_for_top_in_2) == 0):
+        top_val_in_2 = 0
+    else:
+        top_val_in_2 = predictions_for_top_in_2[0][2]
+    return float(top_val_from_1)-float(top_val_in_2)
+

--- a/quiver_engine/server.py
+++ b/quiver_engine/server.py
@@ -20,7 +20,7 @@ from scipy.misc import imsave
 from imagenet_utils import decode_predictions
 from util import deprocess_image, load_img, get_json
 from layer_result_generators import get_outputs_generator
-
+from occlusion import occlude_and_predict
 
 def get_app(model, temp_folder='./tmp', input_folder='./'):
     get_evaluation_context = get_evaluation_context_getter()
@@ -67,6 +67,17 @@ def get_app(model, temp_folder='./tmp', input_folder='./'):
     @app.route('/model')
     def get_config():
         return jsonify(json.loads(model.to_json()))
+
+    @app.route('/occlusion/<input_path>')
+    def get_occlusion(input_path):
+        input_img = load_img(input_path, single_input_shape)
+        filename = get_output_name(temp_folder, 'occlusion', input_path, 0)
+
+        with get_evaluation_context():
+            occluded_mask = occlude_and_predict(model,input_img)
+            imsave(filename,occluded_mask)
+
+        return jsonify(filename)
 
     @app.route('/layer/<layer_name>/<input_path>')
     def get_layer_outputs(layer_name, input_path):

--- a/quiver_engine/util.py
+++ b/quiver_engine/util.py
@@ -22,7 +22,10 @@ def deprocess_image(x):
     return x
 
 def load_img_scaled(input_path, target_shape):
-    return image.img_to_array(image.load_img(input_path, target_size=target_shape)) / 255.0
+    return np.expand_dims(
+        image.img_to_array(image.load_img(input_path, target_size=target_shape)) / 255.0,
+        axis=0
+    )
 
 def load_img(input_path, target_shape):
     img = image.load_img(input_path, target_size=target_shape)

--- a/quiver_engine/util.py
+++ b/quiver_engine/util.py
@@ -21,6 +21,9 @@ def deprocess_image(x):
 
     return x
 
+def load_img_scaled(input_path, target_shape):
+    return image.img_to_array(image.load_img(input_path, target_size=target_shape)) / 255.0
+
 def load_img(input_path, target_shape):
     img = image.load_img(input_path, target_size=target_shape)
 


### PR DESCRIPTION
for input:

![car](https://cloud.githubusercontent.com/assets/1224887/20351015/6c44313c-ac11-11e6-89b0-ffafbcd6b39f.jpg)

and an ImageNet3 model from keras we get output an image like this:

![car_mask](https://cloud.githubusercontent.com/assets/1224887/20354644/206dce86-ac1f-11e6-9c98-29831b97085f.png)


which highlights the areas of an image that mostly contributed to the final top class in classification.
This is done by repeatedly occluding parts of the images and checking model predictions for each of the image. The bigger the drop in prediction for the top-class the whiter the area in the result image.

I would be really happy to tweak the code in terms of performance, clarity and quality, but I put it here as a first working example for a review. Currently it is doing about 36 predictions for each image and we could improve the details of the mask by doing more but this takes a moment already.
Apart from this I've changed the way the image is loaded for my case since I think what is done for 'predict' is wrong - I will double check that and open a new issue to discuss if needed.

This introduce just an endpoint in the server. no bloody idea how to do the GUI part but I imagine that this thing should fire up whenever someone selects an input image and could be shown near the classification scores.


