### PR TITLE
Fix: Predictions not shown

### DIFF
--- a/quiver_engine/server.py
+++ b/quiver_engine/server.py
@@ -13,7 +13,7 @@ from flask_cors import CORS
 from gevent.wsgi import WSGIServer
 
 from quiver_engine.util import (
-    load_img, safe_jsonnify, decode_predictions,
+    load_img, safe_jsonify, decode_predictions,
     get_input_config, get_evaluation_context,
     validate_launch
 )
@@ -103,7 +103,7 @@ def get_app(model, classes, top, html_base_dir, temp_folder='./tmp', input_folde
     @app.route('/predict/<input_path>')
     def get_prediction(input_path):
         with get_evaluation_context():
-            return safe_jsonnify(
+            return safe_jsonify(
                 decode_predictions(
                     model.predict(
                         load_img(

--- a/quiver_engine/util.py
+++ b/quiver_engine/util.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import json
+from flask.json import jsonify
 import numpy as np
 from keras.preprocessing import image
 import keras.backend as K
@@ -90,7 +91,7 @@ def get_jsonable_obj(obj):
 def get_json(obj):
     return json.dumps(obj, default=get_json_type)
 
-def safe_jsonnify(obj):
+def safe_jsonify(obj):
     return jsonify(get_jsonable_obj(obj))
 
 def get_json_type(obj):


### PR DESCRIPTION
Predictions were not shown because of a missing import. This PR

- adds the missing `jsonfiy` import in `quiver_engine/util.py`
- fixes spelling from `safe_jsonnify` to `safe_jsonify`