### PR TITLE
add the ability to accept scaled images as model input

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ This will launch the visualization at `localhost:5000`
         input_folder='./',
 
         # the localhost port the dashboard is to be served on
-        port=5000
+        port=5000,
+
+	# whether your network expects pixels to be scaled to [0,1] or not
+	img_scaled=True
     )
 ```
 


### PR DESCRIPTION
Some networks are designed in a way that they expect input data to be scaled to [0,1] at the input instead of [0,255] - this adds ability to specify that for quiver, so that it works consistently with the modei