### PR TITLE
Add support for decoding binary classifications

### DIFF
--- a/quiver_engine/util.py
+++ b/quiver_engine/util.py
@@ -48,7 +48,22 @@ def decode_predictions(preds, classes, top):
         print("Warning! you didn't pass your own set of classes for the model therefore imagenet classes are used")
         return decode_imagenet_predictions(preds, top)
 
-    if len(preds.shape) != 2 or preds.shape[1] != len(classes):
+    if len(preds.shape) != 2:
+        raise ValueError('prediction output has wrong shape')
+
+    # Binary classification gets special treatment. It is assumed that the
+    # outputs are 0 or 1.
+    if preds.shape[1] == 1 and len(classes) == 2:
+        return [
+            [
+                ("", classes[0], 1-pred[0]),
+                ("", classes[1], pred[0])
+            ]
+            for pred in preds
+        ]
+
+    # Multi-label classification
+    if preds.shape[1] != len(classes):
         raise ValueError('you need to provide same number of classes as model prediction output ' + \
                          'model returns %s predictions, while there are %s classes' % (
                              preds.shape[1], len(classes)))


### PR DESCRIPTION
This PR adds support for decoding predictions from networks where the final layer has exactly one output dimension and two output classes (assumed to be between 0 or 1).

This is useful for binary classification networks. I found that for binary classification, a single-output prediction layer works better than having two outputs, which is why I think it made sense to add a special case for this, but I understand if you feel this is too specific. I thought I would open a PR just in case :slightly_smiling_face: 

Thanks for this awesome tool! :beers: I'm using it over [here](https://github.com/dlebech/is-mila).