### PR TITLE
Update Model call to Keras 2 API

### DIFF
--- a/quiver_engine/layer_result_generators.py
+++ b/quiver_engine/layer_result_generators.py
@@ -3,6 +3,6 @@ from keras.models import Model
 
 def get_outputs_generator(model, layer_name):
     return Model(
-        input=model.input,
-        output=model.get_layer(layer_name).output
+        inputs=model.input,
+        outputs=model.get_layer(layer_name).output
     ).predict


### PR DESCRIPTION
Changed "output" to "outputs" and "input" to "inputs".
Prevent "UserWarning: Update your `Model` call to the Keras 2 API: `Model(inputs=Tensor("co..., outputs=Tensor("ac...)`"